### PR TITLE
Fix issue #1: primes(max) should return at most max results

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ def is_prime(n):
 def primes(max=10):
     primes = []
     num = 2
-    while len(primes) <= max:
+    while len(primes) < max:
         if is_prime(num):
             primes.append(num)
         num += 1

--- a/test_main.py
+++ b/test_main.py
@@ -1,0 +1,22 @@
+import unittest
+from main import primes, is_prime
+
+class TestPrimes(unittest.TestCase):
+    def test_primes_max_results(self):
+        # Test that primes(max) returns at most max results
+        result = primes(10)
+        self.assertEqual(len(result), 10, "primes(10) should return exactly 10 results")
+
+        result = primes(5)
+        self.assertEqual(len(result), 5, "primes(5) should return exactly 5 results")
+
+        result = primes(1)
+        self.assertEqual(len(result), 1, "primes(1) should return exactly 1 result")
+
+    def test_primes_correctness(self):
+        # Test that the returned numbers are actually prime
+        result = primes(5)
+        self.assertEqual(result, [2, 3, 5, 7, 11], "First 5 prime numbers should be [2, 3, 5, 7, 11]")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This pull request fixes #1.

The issue has been successfully resolved through a targeted fix to the while loop condition in the primes() function. The original bug caused primes(10) to return 11 results because the condition `while len(primes) <= max` would continue until the list had max+1 elements. By changing this to `while len(primes) < max`, the function will now stop when exactly max elements are reached.

The change is verified by the new test cases which:
1. Check that primes(10) returns exactly 10 results
2. Check that primes(5) returns exactly 5 results
3. Verify the actual values are correct ([2,3,5,7,11] for primes(5))

The modification is minimal and directly addresses the core issue by fixing the loop termination condition. The added test suite provides confidence that the function now behaves correctly for different input values and produces the correct prime numbers up to the requested count.